### PR TITLE
ScalaKansai Night Seminar 20170427

### DIFF
--- a/src/main/scala/service/SyukujitsuParser.scala
+++ b/src/main/scala/service/SyukujitsuParser.scala
@@ -107,27 +107,34 @@ object SyukujitsuParser extends RegexParsers {
   }
 
   def convertSyukujitsuMap_recursive(
-        lst: List[SyukujitsuBody],
-        mp: SortedMap[Int, SortedMap[LocalDate, String]] = SortedMap.empty[Int, SortedMap[LocalDate, String]]
+    lst: List[SyukujitsuBody],
+    mp: SortedMap[Int, SortedMap[LocalDate, String]] = SortedMap.empty[Int, SortedMap[LocalDate, String]]
   ): SortedMap[Int, SortedMap[LocalDate, String]] = lst match {
-        case Nil => mp
-        case head :: tail => {
-                if (mp isDefinedAt (head.date.getYear)) {
-                  convertSyukujitsuMap_recursive(tail,
-                          mp.updated(head.date.getYear,
-                                     mp.apply(head.date.getYear) + (head.date -> head.date_name)))
-                } else
-                  convertSyukujitsuMap_recursive(tail,
-                          mp + (head.date.getYear -> SortedMap(head.date -> head.date_name)))
-        }
+    case Nil => mp
+    case head :: tail => {
+      if (mp isDefinedAt (head.date.getYear)) {
+        convertSyukujitsuMap_recursive(
+          tail,
+          mp.updated(
+            head.date.getYear,
+            mp.apply(head.date.getYear) + (head.date -> head.date_name)
+          )
+        )
+      } else
+        convertSyukujitsuMap_recursive(
+          tail,
+          mp + (head.date.getYear -> SortedMap(head.date -> head.date_name))
+        )
+    }
   }
 
-
   def convertSyukujitsuMap_builtin(lst: List[SyukujitsuBody]) =
-    lst.groupBy(_.date.getYear).map { e =>
-        (e._1 -> e._2.foldLeft(Map[LocalDate, String]())((b, s) => (b ++ Map(s.date -> s.date_name))))
+    lst.groupBy(_.date.getYear).map {
+      case (year, shukujitsuBodyList) =>
+        year -> shukujitsuBodyList.map { s =>
+          s.date -> s.date_name
+        }.toMap
     }
-
 
   def convertYearMapList(
     lst: List[SyukujitsuBody],

--- a/src/test/scala/service/SykujitsuParserSpec.scala
+++ b/src/test/scala/service/SykujitsuParserSpec.scala
@@ -233,11 +233,11 @@ class SykujitsuParserSpec extends FunSpec with Matchers {
       res should equal(resMap)
     }
 
-    it("convert to Map by builtin"){
+    it("convert to Map by builtin") {
       val resultParse = SyukujitsuParser.parse(testOK)
-      val res:Option[Map[Int, Map[LocalDate,String]]] = resultParse match {
+      val res: Option[Map[Int, Map[LocalDate, String]]] = resultParse match {
         case Right(result) => Some(SyukujitsuParser.convertSyukujitsuMap_builtin(result))
-        case Left(msg)     => None
+        case Left(msg) => None
       }
 
       // println(ListMap(res.get.toSeq.sortBy(_._1):_*))


### PR DESCRIPTION
Scala関西勉強会 ナイトセミナーでは、ありがとうございました。
https://connpass.com/event/54388/

こちら、当日、参加者の皆様でライブコーディングした成果です。

なお、sbtのフォーマッターにより、実際に修正したところ以外も変更になっていますが、

```scala
   lst.groupBy(_.date.getYear).map {
     case (year, shukujitsuBodyList) =>
       year -> shukujitsuBodyList.map { s =>
         s.date -> s.date_name
       }.toMap
```

こちらが、当日、書いてみたコードになります。